### PR TITLE
Update header navigation layout after logo removal.

### DIFF
--- a/dashboard/src/components/layout/HomeNavBar.tsx
+++ b/dashboard/src/components/layout/HomeNavBar.tsx
@@ -1,5 +1,4 @@
 import { ModeToggle } from "../mode-toggle";
-import logo from "@/assets/img/Digiations.png"
 import { NavigationMenu, NavigationMenuContent, NavigationMenuItem, NavigationMenuLink, NavigationMenuList, NavigationMenuTrigger } from "../ui/navigation-menu";
 import { BadgeCent, CircleUserRound, Factory, Grid2x2, Waypoints, Phone, Building2, Users, Cpu, Stethoscope, Monitor } from "lucide-react";
 import { Link } from "react-router-dom";
@@ -51,16 +50,10 @@ function HomeNavBar() {
 
     return (
         <div className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${isScrolled ? 'p-2 backdrop-blur-md bg-background/80 ' : 'p-3'}`}>
-            <div className="flex items-center justify-between max-w-7xl mx-auto">
-                {/* Logo */}
-                <Link to={'/'}>
-                    <div className="flex items-center">
-                        <img src={logo} alt="Digiation" className="w-30" />
-                    </div>
-                </Link>
-
+            <div className="relative flex items-center max-w-7xl mx-auto">
+                <div className="flex-1" />
                 {/* Navigation Menu */}
-                <div className="hidden md:flex items-center space-x-8">
+                <div className="hidden md:flex items-center space-x-8 absolute left-1/2 -translate-x-1/2">
                     <Link to={'/'} className="text-foreground hover:text-primary transition-colors font-medium">
                         Home
                     </Link>
@@ -103,7 +96,7 @@ function HomeNavBar() {
                     </Link>
                 </div>
 
-                <div className="flex items-center space-x-4">
+                <div className="ml-auto flex items-center space-x-4">
                     <ModeToggle />
                 </div>
             </div>

--- a/dashboard/src/components/layout/NavBar.tsx
+++ b/dashboard/src/components/layout/NavBar.tsx
@@ -1,5 +1,4 @@
 import { ModeToggle } from "../mode-toggle";
-import logo from "@/assets/img/Digiations.png"
 import { NavigationMenu, NavigationMenuContent, NavigationMenuItem, NavigationMenuLink, NavigationMenuList, NavigationMenuTrigger } from "../ui/navigation-menu";
 import { BadgeCent, CircleUserRound, Dock, DockIcon, Factory, Grid2x2, Waypoints } from "lucide-react";
 import { Link } from "react-router-dom";
@@ -59,18 +58,6 @@ function NavBar() {
     const { textScalar, barScalar, iScalar } = useResponsiveScalars();
     return (
         <div className="px-3 justify-between h-fit border-border backdrop-blur-md flex w-full min-[2000px]:py-[1px] items-center">
-
-            {/* Digiations Logo */}
-            <Link to={'/'}>
-                <div className="">
-                    <img
-                        src={logo}
-                        alt="Digiation"
-                        style={{
-                            width: `${5 * textScalar}rem`, // logo scales with barScalar
-                        }} />
-                </div>
-            </Link>
 
             {currentRoute &&
                 (<div className="text-muted-foreground max-md:hidden font-medium"


### PR DESCRIPTION
Hide logo elements in both navbar components and keep the home menu centered regardless of right-side controls for consistent header alignment.

Made-with: Cursor